### PR TITLE
Add fireflies-lume1 configs from loneocean's repo

### DIFF
--- a/ToyKeeper/hwdef-fireflies-lume1.h
+++ b/ToyKeeper/hwdef-fireflies-lume1.h
@@ -1,0 +1,200 @@
+#ifndef HWDEF_FIREFLIES_LUME1_H
+#define HWDEF_FIREFLIES_LUME1_H
+
+/* lume1 Driver Rev B for Fireflies driver layout (attiny1634)
+ * Updated for Anduril2
+ * www.loneoceans.com/labs/ for more information
+ *
+ * Pin / Name / Function in Lume1-Fireflies
+ *   1    PA6   Regulated PWM (PWM1B) CTRL Line - 10 bit
+ *   2    PA5   R red aux LED (PWM0B)
+ *   3    PA4   G green aux LED
+ *   4    PA3   B blue aux LED
+ *   5    PA2   e-switch (PCINT2) ESW
+ *   6    PA1   Jumper 1
+ *   7    PA0   Jumper 2 
+ *   8    GND   GND
+ *   9    VCC   VCC
+ *  10    PC5   Jumper 3
+ *  11    PC4   Jumper 4
+ *  12    PC3   nRESET
+ *  13    PC2   External Thermal Sensor (ADC11)
+ *  14    PC1   SCK
+ *  15    PC0   8BitPWM (PWM0A) - 8 bit - NOT USED
+ *  16    PB3   FET PWM (PWM1A) - 10 bit
+ *  17    PB2   MISO
+ *  18    PB1   MOSI
+ *  19    PB0   ADC5 Voltage Battery Sense (2:1 divider)
+ *  20    PA7   BUCK_Enable
+ *				ADC12   internal thermal sensor (not used for lume1)
+ *
+ * Main LED power uses one pin as a global Buck Enable, and 
+ * one pin to control the power level via PWM. Another pin is used
+ * for FET control.
+ * 
+ */
+
+#ifdef ATTINY
+#undef ATTINY
+#endif
+#define ATTINY 1634
+#include <avr/io.h>
+
+#define PWM_CHANNELS 2
+// Added for Lume1 Driver
+#define PWM_BITS 10  // 0 to 1023 at 3.9 kHz, not 0 to 255 at 15.6 kHz
+#define PWM_TOP 1023
+
+#define SWITCH_PIN   PA2    // pin 5
+#define SWITCH_PCINT PCINT2 // pin 5 pin change interrupt
+#define SWITCH_PCIE  PCIE0  // PCIE0 is for PCINT[7:0]
+#define SWITCH_PCMSK PCMSK0 // PCMSK0 is for PCINT[7:0]
+#define SWITCH_PORT  PINA   // PINA or PINB or PINC
+
+#define PWM1_PIN PA6        // pin 1, Buck CTRL pin or 7135-eqv PWM
+#define PWM1_LVL OCR1B      // OCR1A is the output compare register for PA6
+
+#define PWM2_PIN PB3        // pin 16, FET PWM Pin
+#define PWM2_LVL OCR1A      // OCR1A is the output compare register for PB3
+
+// Added for Lume1 Buck Driver
+#define LED_ENABLE_PIN  PA7    // pin 20, Buck Enable
+#define LED_ENABLE_PORT PORTA  // control port for PA7
+
+/* // For Jumpers X1 to X4, no SW support yet
+#define JUMPER1_PIN PA1
+#define JUMPER2_PIN PA0
+#define JUMPER3_PIN PC5
+#define JUMPER4_PIN PC4
+*/
+
+/*
+// average drop across diode on this hardware
+// not applicable for LUME1 driver
+#ifndef VOLTAGE_FUDGE_FACTOR
+#define VOLTAGE_FUDGE_FACTOR 4  // add 0.20V  (measured 0.22V)
+#endif
+*/
+
+#define USE_VOLTAGE_DIVIDER     // use a dedicated pin, not VCC, because VCC input is flattened
+#define VOLTAGE_PIN PB0         // Pin 19  PB0  ADC5
+// pin to ADC mappings are in DS table 19-4
+#define VOLTAGE_ADC ADC5D       // digital input disable pin for PB1
+// DIDR0/DIDR1 mappings are in DS section 19.13.5, 19.13.6
+#define VOLTAGE_ADC_DIDR DIDR1  // DIDR channel for ADC5D
+// DS tables 19-3, 19-4
+// Bit   7     6     5      4     3    2    1    0
+//     REFS1 REFS0 REFEN ADC0EN MUX3 MUX2 MUX1 MUX0
+// MUX[3:0] = 0, 1, 0, 1 for ADC5 / PB0
+// divided by ...
+// REFS[1:0] = 0, 0 for VCC as analog reference at 2.5V
+// other bits reserved
+#define ADMUX_VOLTAGE_DIVIDER 0b00000101
+#define ADC_PRSCL   0x06        // clk/64
+
+// Raw ADC readings at 4.4V and 2.2V
+// calibrate the voltage readout here
+// estimated / calculated values are:
+// [(Vbatt)*(R2/(R2+R1)) / 2.5V] * 1023
+// R1 = R2 = 100kR
+#ifndef ADC_44
+#define ADC_44 900
+#endif
+#ifndef ADC_22
+#define ADC_22 450
+#endif
+
+// Default ADMUX_THERM for Temperature is: 0b10001110 in tk-attiny.h
+// REFS[1:0] as 10 for analog reference at internal 1.1Vref
+// MUX[3:0] as 1110 for ADC'12' - temperature sensor internal
+
+// Modified fsm-adc.c to use different ADMUX and ADC_temperature_handler()
+// based on USE_EXTERNAL_TEMP_SENSOR
+// See line 34 and line 209
+#define USE_EXTERNAL_TEMP_SENSOR
+#define ADMUX_THERM_EXTERNAL_SENSOR 0b00001011  // VCC reference (2.5V), Channel PC2
+// #define TEMP_CHANNEL 0b00001111
+// Used for Lume1 Driver MCP9700: T_Celsius = 100*(VOUT - 0.5V)
+// ADC is 2.5V reference, 0 to 1023
+// FIXME: due to floating point, this calculation takes 916 extra bytes
+//        (should use an integer equivalent instead)
+#define EXTERN_TEMP_FORMULA(m) (((m)-205)/4.09) // takes a 10-bit ADC Value and gives Celsius
+#define EXTERN_TEMP_REVERSE_FORMULA(t) (((t)*4.09)+205) // takes t_Celsius and gives a 10-bit ADC Value 
+// modified fsm-adc.c line ~384 to add in reverse formula
+
+// this driver allows for aux LEDs under the optic
+#define AUXLED_R_PIN   PA5    // pin 2
+#define AUXLED_G_PIN   PA4    // pin 3
+#define AUXLED_B_PIN   PA3    // pin 4
+#define AUXLED_RGB_PORT PORTA // PORTA or PORTB or PORTC
+#define AUXLED_RGB_DDR DDRA   // DDRA or DDRB or DDRC
+#define AUXLED_RGB_PUE PUEA   // PUEA or PUEB or PUEC
+
+// with so many pins, doing this all with #ifdefs gets awkward...
+// ... so just hardcode it in each hwdef file instead
+// For lume1 driver, no SW support for Auxillary Jumpers X1 to X4 yet!
+inline void hwdef_setup() {
+  // enable output ports in Data Direction Registers
+  // Buck Enable Pin
+  // DDRA = (1 << LED_ENABLE_PIN);
+  
+  // FET PWM Pin
+  DDRB = (1 << PWM2_PIN);
+  // Main PWM, aux R/G/B
+  DDRA = (1 << PWM1_PIN)
+       | (1 << AUXLED_R_PIN)
+       | (1 << AUXLED_G_PIN)
+       | (1 << AUXLED_B_PIN)
+       | (1 << LED_ENABLE_PIN)
+       ;
+  // Moon PWM Pin
+  //DDRC = (1 << PWM3_PIN);
+
+  //DDRB&=~(1<<VOLTAGE_PIN); // All pins are input by default
+
+  /* // For Jumpers X1 to X4, no SW support yet
+  DDRA &= (1<<JUMPER1_PIN);
+  DDRA &= (1<<JUMPER2_PIN);
+  DDRC &= (1<<JUMPER3_PIN);
+  DDRC &= (1<<JUMPER4_PIN);
+  PUEA = (1 << JUMPER1_PIN); 
+  PUEA = (1 << JUMPER2_PIN); 
+  PUEC = (1 << JUMPER3_PIN); 
+  PUEC = (1 << JUMPER4_PIN); 
+  */
+
+  // configure PWM for 10 bit at 3.9kHz
+  // Setup PWM. F_pwm = F_clkio / 2 / N / TOP, where N = prescale factor, TOP = top of counter
+  // pre-scale for timer: N = 1
+  // WGM1[3:0]: 0,0,1,1: PWM, Phase Correct, 10-bit (DS table 12-5)
+  // CS1[2:0]:    0,0,1: clk/1 (No prescaling) (DS table 12-6)
+  // COM1A[1:0]:    1,0: PWM OC1A in the normal direction (DS table 12-4)
+  // COM1B[1:0]:    1,0: PWM OC1B in the normal direction (DS table 12-4)
+  TCCR1A  = (1<<WGM11)  | (1<<WGM10)   // 10-bit (TOP=0x03FF) (DS table 12-5)
+          | (1<<COM1A1) | (0<<COM1A0)  // PWM 1A Clear OC1A on Compare Match
+          | (1<<COM1B1) | (0<<COM1B0)  // PWM 1B Clear OC1B on Compare Match
+          ;
+  TCCR1B  = (0<<CS12)   | (0<<CS11) | (1<<CS10)  // clk/1 (no prescaling) (DS table 12-6)
+          | (0<<WGM13)  | (0<<WGM12)  // PWM, Phase Correct, 10-bit
+          ;
+
+ /*
+  // Added support for PWM0A PWM (8 bit instead of 10 bits)
+  TCCR0A  = (0<<WGM01)  | (1<<WGM00)   // 8-bit (TOP=0xFF)
+          | (1<<COM0A1) | (0<<COM0A0)  // PWM 0A in normal direction (DS table 12-4)
+          | (0<<COM0B1) | (0<<COM0B0)  // PWM 0B normal port operation
+          ;
+  TCCR0B  = (0<<CS02)   | (0<<CS01) | (1<<CS00)  // clk/1 (no prescaling) (DS table 12-6)
+          | (0<<WGM02)  // phase-correct PWM (DS table 12-5)
+          ;
+ */
+
+  // set up e-switch
+  //PORTA = (1 << SWITCH_PIN);  // TODO: configure PORTA / PORTB / PORTC?
+  PUEA = (1 << SWITCH_PIN);  // pull-up for e-switch
+  SWITCH_PCMSK = (1 << SWITCH_PCINT);  // enable pin change interrupt
+}
+
+#define LAYOUT_DEFINED
+
+#endif

--- a/ToyKeeper/spaghetti-monster/anduril/cfg-fireflies-lume1-nofet.h
+++ b/ToyKeeper/spaghetti-monster/anduril/cfg-fireflies-lume1-nofet.h
@@ -1,0 +1,190 @@
+
+/* Lume-Fireflies Driver config options
+ * - Anduril 2 Firmware by Selene Scriven
+ * - 6A Single Cell Constant Current Buck + FET driver, with 2A USB-C Charging
+ * - Developed at request of Fireflies / FireflyLite Flashlight Manufacturer
+ * 
+ * For more information: 
+ * - www.loneoceans.com/labs/
+ * - Manual: http://toykeeper.net/torches/fsm/anduril2/anduril-manual.txt
+ * - 1634 Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
+ * - Code Repo: https://bazaar.launchpad.net/~toykeeper/flashlight-firmware/anduril2/files/head:/ToyKeeper/spaghetti-monster/anduril
+ */
+
+// TODO: determine if "04" (Fireflylite) is the right prefix,
+//       or if there should be a brand ID for Loneoceans
+// For Fireflies / FireflyLite Lume1
+// To be used in several flashlights (e.g. E12R, E07X...
+//       but Jack from Fireflies isn't making it clear to me which ones...)
+#define MODEL_NUMBER "0443"	
+
+#include "hwdef-fireflies-lume1.h"
+// ATTINY: 1634
+
+
+//***************************************
+//**       THERMAL SETTINGS            **
+//***************************************
+
+/* THERMAL MODIFICATONS
+
+   Some modifications were made to enable the following scenario in Fireflies E12R.
+   The FET has 3.9kHz PWM, and thermal gradual stepdown causes a whine.
+   Change behavior so that thermal stepdown is a step response directly to 6A.
+   Levels 1 to 149 are CC, 150 is turbo at 100% no PWM. 
+   In addition, since body and sensor temperatures have a lag, add TURBO_TEMP_EXTRA.
+   So only when temperature >temp_ceil+TURBO_TEMP_EXTRA && ramp is at 150, then drop.
+   Otherwise, thermal regulation remains at user set temp_ceil (either default or in EEprom).
+
+   Modified fsm-adc.c at line 422
+            // send a warning
+        >>  if ((temperature < (therm_ceil + TURBO_TEMP_EXTRA))&&(actual_level==150)){;}
+        >>  else{emit(EV_temperature_high, howmuch);}
+            //emit(EV_temperature_high, howmuch);
+
+	And, modified ramp-mode.c at line 298
+	        #ifdef USE_SET_LEVEL_GRADUALLY
+            //set_level_gradually(stepdown);
+        >>  if (actual_level == 150) {set_level(149);}
+        >>  else {set_level_gradually(stepdown);}
+*/
+
+// set this light for 50C thermal ceiling
+#undef DEFAULT_THERM_CEIL
+#define DEFAULT_THERM_CEIL 50
+//#define MAX_THERM_CEIL 70 // default maximum value
+
+// drop from turbo at therm_ceil+TURBO_TEMP_EXTRA
+#define TURBO_TEMP_EXTRA 7 // in celsius
+
+// do not recalibrate light temperature to 21C upon factory reset!
+// Lume driver has a calibrated temperature sensor already
+// Not implemented yet, manually commented out (TODO)
+//#define NO_TEMP_CAL_DURING_RESET
+
+// optional, makes initial turbo step-down faster so first peak isn't as hot
+// FET mode can run very very hot, so be extra careful
+//#define THERM_HARD_TURBO_DROP
+
+// stop panicking at ~3A (not sure of this numbers yet since it depends on the host..)
+#define THERM_FASTER_LEVEL 116
+#define MIN_THERM_STEPDOWN 69         // 760mA
+#define THERM_NEXT_WARNING_THRESHOLD 16  // accumulate less error before adjusting (default 24)
+#define THERM_RESPONSE_MAGNITUDE 96   // bigger adjustments (default 64)
+
+// respond to thermal changes faster
+//#define THERMAL_WARNING_SECONDS 3
+//#define THERMAL_UPDATE_SPEED 1
+//#define THERM_PREDICTION_STRENGTH 4
+
+// easier access to thermal config mode, similar to Emisar, Noctigon
+#define USE_TENCLICK_THERMAL_CONFIG
+
+
+
+//***************************************
+//**      RAMPS AND OPERATIONS         **
+//***************************************
+
+// Uncomment to get Max Turbo on 2C from Off
+//#define USE_2C_MAX_TURBO
+
+// set this light to use stepped ramp by default (instead of smooth)
+#undef RAMP_STYLE
+#define RAMP_STYLE 1
+
+// ../../bin/level_calc.py cube 1 149 7135 0 0.5 1000, with 0 appended to the end.
+// for FET PWM (PWM2), all values are 0, except for last value of 1023
+// (with max_pwm set to 1023)
+
+// For FET version (length 150)
+//#define RAMP_LENGTH 150
+//#define PWM1_LEVELS 1,2,3,3,3,3,3,4,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,12,13,14,15,16,17,18,20,21,23,24,26,27,29,31,33,35,37,39,41,43,45,48,50,53,56,58,61,64,67,70,74,77,80,84,88,91,95,99,103,108,112,116,121,125,130,135,140,145,150,156,161,167,173,178,184,191,197,203,210,217,223,230,238,245,252,260,268,275,283,292,300,308,317,326,335,344,353,363,372,382,392,402,413,423,434,445,456,467,478,490,502,514,526,538,551,563,576,589,603,616,630,644,658,672,687,702,717,732,747,763,778,794,811,827,844,861,878,895,913,931,949,967,985,1004,1023,0
+//#define PWM2_LEVELS 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1023
+//For no FET version (length 149)
+#define RAMP_LENGTH 149
+#define PWM1_LEVELS 1,2,3,3,3,3,3,4,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,12,13,14,15,16,17,18,20,21,23,24,26,27,29,31,33,35,37,39,41,43,45,48,50,53,56,58,61,64,67,70,74,77,80,84,88,91,95,99,103,108,112,116,121,125,130,135,140,145,150,156,161,167,173,178,184,191,197,203,210,217,223,230,238,245,252,260,268,275,283,292,300,308,317,326,335,344,353,363,372,382,392,402,413,423,434,445,456,467,478,490,502,514,526,538,551,563,576,589,603,616,630,644,658,672,687,702,717,732,747,763,778,794,811,827,844,861,878,895,913,931,949,967,985,1004,1023
+#define PWM2_LEVELS 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+
+#define DEFAULT_LEVEL 44  // About ~250mA
+#define MAX_1x7135 69     // About ~760mA, MIN_THERM_STEPDOWN defined as MAX_1x7135 in ramp-mode.h if not otherwise defined
+
+// TODO CHECK WHAT THESE DO
+// TODO: test if underclocking works on lume1
+//#define HALFSPEED_LEVEL 14
+//#define QUARTERSPEED_LEVEL 5
+
+// the entire ramp is regulated; don't blink halfway up
+#ifdef BLINK_AT_RAMP_MIDDLE
+#undef BLINK_AT_RAMP_MIDDLE
+#endif
+
+// don't slow down at low levels; this isn't that sort of light
+// (it needs to stay at full speed for the 10-bit PWM to work)
+#ifdef USE_DYNAMIC_UNDERCLOCKING
+#undef USE_DYNAMIC_UNDERCLOCKING
+#endif
+
+//#define RAMP_SMOOTH_FLOOR 1
+#define RAMP_SMOOTH_FLOOR 3   // requested by Fireflies
+#define RAMP_SMOOTH_CEIL 149  // Level 150 is when Buck is off and FET is ON 100%
+
+#define RAMP_DISCRETE_FLOOR 3
+#define RAMP_DISCRETE_CEIL RAMP_SMOOTH_CEIL
+#define RAMP_DISCRETE_STEPS 5
+
+#define SIMPLE_UI_FLOOR 3
+#define SIMPLE_UI_CEIL 149  // 139 for 5A max
+#define SIMPLE_UI_STEPS 5
+
+// Note: floor begins at 3; user can use 7H config menu to change 
+// floor to 1 or 2 (for value 1 or 2 respectively) - requested by Fireflies
+
+// Turn on Buck from level 1 to 149, but not 150
+// Level 150 is when Buck is off and FET is ON 100%
+#define LED_ENABLE_PIN_LEVEL_MIN 1
+#define LED_ENABLE_PIN_LEVEL_MAX 149
+
+
+
+//***************************************
+//**       AUX LEDs and MISC           **
+//***************************************
+
+// this light has three aux LED channels: R, G, B
+#define USE_AUX_RGB_LEDS
+
+// it has no independent LED in the button unlike emisar d4 for example
+//#define USE_BUTTON_LED
+
+// the aux LEDs are front-facing, so turn them off while main LEDs are on
+// TODO: the whole "indicator LED" thing needs to be refactored into
+//       "aux LED(s)" and "button LED(s)" since they work a bit differently
+#ifdef USE_INDICATOR_LED_WHILE_RAMPING
+#undef USE_INDICATOR_LED_WHILE_RAMPING
+#endif
+#define RGB_LED_OFF_DEFAULT 0x18  // low, voltage
+#define RGB_LED_LOCKOUT_DEFAULT 0x37  // blinking, rainbow
+
+// enable blinking aux LEDs
+#define TICK_DURING_STANDBY
+#define STANDBY_TICK_SPEED 3  // every 0.128 s
+//#define STANDBY_TICK_SPEED 4  // every 0.256 s
+//#define STANDBY_TICK_SPEED 5  // every 0.512 s
+
+#define USE_SOS_MODE
+#define USE_SOS_MODE_IN_BLINKY_GROUP
+
+// uncomment to use Beacon Tower mode (after alpine beacon in 3C blinky modes)
+//#define USE_BEACONTOWER_MODE
+
+// party strobe on-time
+#define PARTY_STROBE_ONTIME 4
+
+//#define THERM_CAL_OFFSET 0	// was 5 from Noctigon
+
+// attiny1634 has enough space to smooth out voltage readings
+#define USE_VOLTAGE_LOWPASS
+
+// can't reset the normal way because power is connected before the button
+#define USE_SOFT_FACTORY_RESET

--- a/ToyKeeper/spaghetti-monster/anduril/cfg-fireflies-lume1.h
+++ b/ToyKeeper/spaghetti-monster/anduril/cfg-fireflies-lume1.h
@@ -1,0 +1,190 @@
+
+/* Lume-Fireflies Driver config options
+ * - Anduril 2 Firmware by Selene Scriven
+ * - 6A Single Cell Constant Current Buck + FET driver, with 2A USB-C Charging
+ * - Developed at request of Fireflies / FireflyLite Flashlight Manufacturer
+ * 
+ * For more information: 
+ * - www.loneoceans.com/labs/
+ * - Manual: http://toykeeper.net/torches/fsm/anduril2/anduril-manual.txt
+ * - 1634 Datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
+ * - Code Repo: https://bazaar.launchpad.net/~toykeeper/flashlight-firmware/anduril2/files/head:/ToyKeeper/spaghetti-monster/anduril
+ */
+
+// TODO: determine if "04" (Fireflylite) is the right prefix,
+//       or if there should be a brand ID for Loneoceans
+// For Fireflies / FireflyLite Lume1
+// To be used in several flashlights (e.g. E12R, E07X...
+//       but Jack from Fireflies isn't making it clear to me which ones...)
+#define MODEL_NUMBER "0443"	
+
+#include "hwdef-fireflies-lume1.h"
+// ATTINY: 1634
+
+
+//***************************************
+//**       THERMAL SETTINGS            **
+//***************************************
+
+/* THERMAL MODIFICATONS
+
+   Some modifications were made to enable the following scenario in Fireflies E12R.
+   The FET has 3.9kHz PWM, and thermal gradual stepdown causes a whine.
+   Change behavior so that thermal stepdown is a step response directly to 6A.
+   Levels 1 to 149 are CC, 150 is turbo at 100% no PWM. 
+   In addition, since body and sensor temperatures have a lag, add TURBO_TEMP_EXTRA.
+   So only when temperature >temp_ceil+TURBO_TEMP_EXTRA && ramp is at 150, then drop.
+   Otherwise, thermal regulation remains at user set temp_ceil (either default or in EEprom).
+
+   Modified fsm-adc.c at line 422
+            // send a warning
+        >>  if ((temperature < (therm_ceil + TURBO_TEMP_EXTRA))&&(actual_level==150)){;}
+        >>  else{emit(EV_temperature_high, howmuch);}
+            //emit(EV_temperature_high, howmuch);
+
+	And, modified ramp-mode.c at line 298
+	        #ifdef USE_SET_LEVEL_GRADUALLY
+            //set_level_gradually(stepdown);
+        >>  if (actual_level == 150) {set_level(149);}
+        >>  else {set_level_gradually(stepdown);}
+*/
+
+// set this light for 50C thermal ceiling
+#undef DEFAULT_THERM_CEIL
+#define DEFAULT_THERM_CEIL 50
+//#define MAX_THERM_CEIL 70 // default maximum value
+
+// drop from turbo at therm_ceil+TURBO_TEMP_EXTRA
+#define TURBO_TEMP_EXTRA 7 // in celsius
+
+// do not recalibrate light temperature to 21C upon factory reset!
+// Lume driver has a calibrated temperature sensor already
+// Not implemented yet, manually commented out (TODO)
+//#define NO_TEMP_CAL_DURING_RESET
+
+// optional, makes initial turbo step-down faster so first peak isn't as hot
+// FET mode can run very very hot, so be extra careful
+//#define THERM_HARD_TURBO_DROP
+
+// stop panicking at ~3A (not sure of this numbers yet since it depends on the host..)
+#define THERM_FASTER_LEVEL 116
+#define MIN_THERM_STEPDOWN 69         // 760mA
+#define THERM_NEXT_WARNING_THRESHOLD 16  // accumulate less error before adjusting (default 24)
+#define THERM_RESPONSE_MAGNITUDE 96   // bigger adjustments (default 64)
+
+// respond to thermal changes faster
+//#define THERMAL_WARNING_SECONDS 3
+//#define THERMAL_UPDATE_SPEED 1
+//#define THERM_PREDICTION_STRENGTH 4
+
+// easier access to thermal config mode, similar to Emisar, Noctigon
+#define USE_TENCLICK_THERMAL_CONFIG
+
+
+
+//***************************************
+//**      RAMPS AND OPERATIONS         **
+//***************************************
+
+// Uncomment to get Max Turbo on 2C from Off
+//#define USE_2C_MAX_TURBO
+
+// set this light to use stepped ramp by default (instead of smooth)
+#undef RAMP_STYLE
+#define RAMP_STYLE 1
+
+// ../../bin/level_calc.py cube 1 149 7135 0 0.5 1000, with 0 appended to the end.
+// for FET PWM (PWM2), all values are 0, except for last value of 1023
+// (with max_pwm set to 1023)
+
+// For FET version (length 150)
+#define RAMP_LENGTH 150
+#define PWM1_LEVELS 1,2,3,3,3,3,3,4,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,12,13,14,15,16,17,18,20,21,23,24,26,27,29,31,33,35,37,39,41,43,45,48,50,53,56,58,61,64,67,70,74,77,80,84,88,91,95,99,103,108,112,116,121,125,130,135,140,145,150,156,161,167,173,178,184,191,197,203,210,217,223,230,238,245,252,260,268,275,283,292,300,308,317,326,335,344,353,363,372,382,392,402,413,423,434,445,456,467,478,490,502,514,526,538,551,563,576,589,603,616,630,644,658,672,687,702,717,732,747,763,778,794,811,827,844,861,878,895,913,931,949,967,985,1004,1023,0
+#define PWM2_LEVELS 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1023
+//For no FET version (length 149)
+//#define RAMP_LENGTH 149
+//#define PWM1_LEVELS 1,2,3,3,3,3,3,4,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,12,13,14,15,16,17,18,20,21,23,24,26,27,29,31,33,35,37,39,41,43,45,48,50,53,56,58,61,64,67,70,74,77,80,84,88,91,95,99,103,108,112,116,121,125,130,135,140,145,150,156,161,167,173,178,184,191,197,203,210,217,223,230,238,245,252,260,268,275,283,292,300,308,317,326,335,344,353,363,372,382,392,402,413,423,434,445,456,467,478,490,502,514,526,538,551,563,576,589,603,616,630,644,658,672,687,702,717,732,747,763,778,794,811,827,844,861,878,895,913,931,949,967,985,1004,1023
+//#define PWM2_LEVELS 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+
+#define DEFAULT_LEVEL 44  // About ~250mA
+#define MAX_1x7135 69     // About ~760mA, MIN_THERM_STEPDOWN defined as MAX_1x7135 in ramp-mode.h if not otherwise defined
+
+// TODO CHECK WHAT THESE DO
+// TODO: test if underclocking works on lume1
+//#define HALFSPEED_LEVEL 14
+//#define QUARTERSPEED_LEVEL 5
+
+// the entire ramp is regulated; don't blink halfway up
+#ifdef BLINK_AT_RAMP_MIDDLE
+#undef BLINK_AT_RAMP_MIDDLE
+#endif
+
+// don't slow down at low levels; this isn't that sort of light
+// (it needs to stay at full speed for the 10-bit PWM to work)
+#ifdef USE_DYNAMIC_UNDERCLOCKING
+#undef USE_DYNAMIC_UNDERCLOCKING
+#endif
+
+//#define RAMP_SMOOTH_FLOOR 1
+#define RAMP_SMOOTH_FLOOR 3   // requested by Fireflies
+#define RAMP_SMOOTH_CEIL 149  // Level 150 is when Buck is off and FET is ON 100%
+
+#define RAMP_DISCRETE_FLOOR 3
+#define RAMP_DISCRETE_CEIL RAMP_SMOOTH_CEIL
+#define RAMP_DISCRETE_STEPS 5
+
+#define SIMPLE_UI_FLOOR 3
+#define SIMPLE_UI_CEIL 149  // 139 for 5A max
+#define SIMPLE_UI_STEPS 5
+
+// Note: floor begins at 3; user can use 7H config menu to change 
+// floor to 1 or 2 (for value 1 or 2 respectively) - requested by Fireflies
+
+// Turn on Buck from level 1 to 149, but not 150
+// Level 150 is when Buck is off and FET is ON 100%
+#define LED_ENABLE_PIN_LEVEL_MIN 1
+#define LED_ENABLE_PIN_LEVEL_MAX 149
+
+
+
+//***************************************
+//**       AUX LEDs and MISC           **
+//***************************************
+
+// this light has three aux LED channels: R, G, B
+#define USE_AUX_RGB_LEDS
+
+// it has no independent LED in the button unlike emisar d4 for example
+//#define USE_BUTTON_LED
+
+// the aux LEDs are front-facing, so turn them off while main LEDs are on
+// TODO: the whole "indicator LED" thing needs to be refactored into
+//       "aux LED(s)" and "button LED(s)" since they work a bit differently
+#ifdef USE_INDICATOR_LED_WHILE_RAMPING
+#undef USE_INDICATOR_LED_WHILE_RAMPING
+#endif
+#define RGB_LED_OFF_DEFAULT 0x18  // low, voltage
+#define RGB_LED_LOCKOUT_DEFAULT 0x37  // blinking, rainbow
+
+// enable blinking aux LEDs
+#define TICK_DURING_STANDBY
+#define STANDBY_TICK_SPEED 3  // every 0.128 s
+//#define STANDBY_TICK_SPEED 4  // every 0.256 s
+//#define STANDBY_TICK_SPEED 5  // every 0.512 s
+
+#define USE_SOS_MODE
+#define USE_SOS_MODE_IN_BLINKY_GROUP
+
+// uncomment to use Beacon Tower mode (after alpine beacon in 3C blinky modes)
+//#define USE_BEACONTOWER_MODE
+
+// party strobe on-time
+#define PARTY_STROBE_ONTIME 4
+
+//#define THERM_CAL_OFFSET 0	// was 5 from Noctigon
+
+// attiny1634 has enough space to smooth out voltage readings
+#define USE_VOLTAGE_LOWPASS
+
+// can't reset the normal way because power is connected before the button
+#define USE_SOFT_FACTORY_RESET

--- a/ToyKeeper/spaghetti-monster/anduril/ramp-mode.c
+++ b/ToyKeeper/spaghetti-monster/anduril/ramp-mode.c
@@ -295,7 +295,27 @@ uint8_t steady_state(Event event, uint16_t arg) {
             if (stepdown < MIN_THERM_STEPDOWN) stepdown = MIN_THERM_STEPDOWN;
             else if (stepdown > MAX_LEVEL) stepdown = MAX_LEVEL;
             #ifdef USE_SET_LEVEL_GRADUALLY
-            set_level_gradually(stepdown);
+                #ifdef TURBO_TEMP_EXTRA
+                    // XXX new variable instead of reusing TURBO_TEMP_EXTRA for this?
+                    /* THERMAL MODIFICATONS
+
+                       Some modifications were made to enable the following scenario in Fireflies E12R.
+                       The FET has 3.9kHz PWM, and thermal gradual stepdown causes a whine.
+                       Change behavior so that thermal stepdown is a step response directly to 6A.
+                       Levels 1 to 149 are CC, 150 is turbo at 100% no PWM. 
+                       In addition, since body and sensor temperatures have a lag, add TURBO_TEMP_EXTRA.
+                       So only when temperature >temp_ceil+TURBO_TEMP_EXTRA && ramp is at 150, then drop.
+                       Otherwise, thermal regulation remains at user set temp_ceil (either default or in EEprom).
+                    */
+                    if (actual_level == 150) {
+                        set_level(149);
+                    }
+                    else {
+                        set_level_gradually(stepdown);
+                    }
+                #else
+                    set_level_gradually(stepdown);
+                #endif
             #else
             set_level(stepdown);
             #endif


### PR DESCRIPTION
Most of this code was copied from:
    https://github.com/loneoceans/lume1-fireflies
    commit 9695c91a5cb80d4e6fdbd179504a1ce6c6e3f60d
    Date:   Sat Jan 16 15:40:08 2021 -0800

I attempted to rework the fireflies-specific patches to make them have
no impact without an #ifdef.